### PR TITLE
Fix race condition in job submission and add recovery logic

### DIFF
--- a/dev_progress.md
+++ b/dev_progress.md
@@ -1,29 +1,65 @@
-# Development Progress
+# Development Progress Report
 
-## Initial Analysis
+## Part 1: Logical Code Flow Analysis
 
-*   **Codebase:** The application consists of a main process (`main.py`) that manages a queue of simulation cases, a file scanner (`case_scanner.py`) to detect new cases, a workflow submitter (`workflow_submitter.py`) to run cases on a remote HPC, and a database manager (`db_manager.py`) using SQLite.
-*   **Workflow:**
-    1.  A new case (directory) is copied into the `new_cases/` directory.
-    2.  `CaseScanner` detects the new directory and adds it to the database with `status='submitted'`.
-    3.  The main loop picks up the 'submitted' case.
-    4.  It locks an available GPU resource from the database.
-    5.  It uses `scp` to transfer the case to the HPC and `ssh` to submit it to a `pueue` queue. The case status becomes 'running'.
-    6.  The main loop monitors 'running' cases by checking their status via `ssh` and `pueue`.
-    7.  When a case finishes, its status is updated to 'completed' or 'failed', and the GPU resource is released.
+The application is designed to process simulation cases by sending them to a remote High-Performance Computing (HPC) environment managed by `pueue`. The logical flow for a new case is as follows:
 
-## Problem 1: Non-functional Dashboard
+1.  **Detection**: A `CaseScanner` service watches a directory (`new_cases/`) for new case folders.
+2.  **DB Registration**: Upon detection, the new case path is registered in a local SQLite database with the status `submitted`.
+3.  **Processing Loop**: The main application loop in `main.py` periodically queries the database for cases with the `submitted` status.
+4.  **Resource Locking**: For each `submitted` case, the application attempts to lock an available GPU resource. The resource is represented by a `pueue` group (e.g., `gpu_a`). If successful, the resource's status is changed to `assigned` in the database.
+5.  **Pre-Submission State Change**: The case's status is updated to `submitting`. **This is a critical point in the original code.**
+6.  **Remote Submission**: The `WorkflowSubmitter` class is used to:
+    a.  Transfer the case files to the HPC via `scp`.
+    b.  Submit a new job to the remote `pueue` daemon via `ssh`.
+7.  **Post-Submission State Change**: If the submission is successful and a `pueue_task_id` is received, the case's status is updated to `running` in the database.
 
-*   **Observation:** The `src/dashboard.py` script is meant to be a monitoring tool but it displays static, hardcoded data. It does not connect to the database to show the actual state of the system.
-*   **Impact:** The dashboard is currently misleading and does not fulfill its purpose.
-*   **Solution:** Modify `src/dashboard.py` to connect to the application's SQLite database. It should periodically fetch the status of all cases and GPU resources and display them in a live-updating table using the `rich` library.
-*   **Resolution:**
-    *   The `src/dashboard.py` script was completely refactored.
-    *   It now loads the database path from `config/config.yaml`.
-    *   It uses the `DatabaseManager` to connect to the SQLite database.
-    *   A `rich.live.Live` display is used to create a terminal-based UI that refreshes every 2 seconds.
-    *   The dashboard now displays two tables: one for the status of all cases and one for the status of all GPU resources.
-    *   The script handles the case where the database file has not been created yet, displaying a helpful message to the user.
-    *   Dependencies (`pyyaml`, `rich`) were identified as missing from the environment and were installed via `pip install -r requirements.txt`.
-    *   The run command was corrected to `python -m src.dashboard` to resolve a `ModuleNotFoundError`.
-    *   The dashboard is now a functional monitoring tool.
+## Part 2: Predicted Problem and Root Cause
+
+A critical flaw was identified in the original workflow. The state of the application could become inconsistent if a crash or shutdown occurred during the "danger zone"—the period after the case status was set to `submitting` but before the remote job's `pueue_task_id` was successfully stored in the local database.
+
+**Problem Trace:**
+
+1.  A case `C1` is picked up, and a GPU resource is locked for it.
+2.  The status of `C1` is updated to `submitting` in the database.
+3.  The `submit_workflow` function successfully creates a job on the remote HPC.
+4.  **The application crashes** before the `pueue_task_id` for the new job is saved for `C1` and its status is updated to `running`.
+
+**Consequence on Restart:**
+
+1.  The application starts up and its recovery logic finds case `C1` in the `submitting` state.
+2.  The original code treated this state as an unrecoverable error. It would automatically change the case's status to `failed` and release the locked GPU resource in the database.
+3.  **This created a severe inconsistency:**
+    *   **Local State:** The database shows case `C1` as `failed` and the GPU as `available`.
+    *   **Remote State:** An **orphaned job** for case `C1` is still running (or queued) on the HPC, consuming a real GPU.
+4.  The application, now believing the GPU is free, would likely assign a new case to it, leading to resource conflicts, job failures, and an unreliable system.
+
+## Part 3: Implemented Solution
+
+To resolve this, the system was refactored to be self-healing and resilient to crashes during submission. The solution involved adding traceability to remote jobs and implementing intelligent recovery logic.
+
+### 1. Enhanced Workflow Submitter for Traceability
+
+The `src/services/workflow_submitter.py` file was modified:
+
+*   The `submit_workflow` method was updated to accept the `case_id`. It now uses the `pueue add` command's `--label` flag to tag each remote job with a unique, predictable identifier (e.g., `mqic_case_123`). This creates a durable link between the local database record and the remote process.
+*   A new method, `find_task_by_label(label)`, was created. This method connects to the HPC, queries `pueue status --json`, and searches for a job with the specified label, returning the job's details if found.
+
+### 2. Implemented Self-Healing Recovery Logic
+
+The main loop in `src/main.py` was significantly improved:
+
+*   The logic for handling cases in the `submitting` state at startup was completely replaced.
+*   The new "self-healing" logic is as follows:
+    1.  For each case found in the `submitting` state, construct the expected label (e.g., `mqic_case_123`).
+    2.  Call the new `workflow_submitter.find_task_by_label()` method to check if a corresponding job already exists on the HPC.
+    3.  **If a matching remote task is found:** This means the submission succeeded, but the local update failed. The application now recovers automatically by:
+        *   Extracting the `pueue_task_id` from the remote job's data.
+        *   Updating the local case record with this `pueue_task_id`.
+        *   Changing the case's status to `running`.
+        *   This action successfully "recovers" the orphaned process and brings the system back into a consistent state.
+    4.  **If no matching remote task is found:** This confirms that the submission process failed before a job was created. It is now safe to:
+        *   Mark the case as `failed`.
+        *   Release the GPU resource in the database.
+
+This solution eliminates the race condition and ensures that the application's state remains consistent even in the event of a crash during the critical submission phase.

--- a/tests/services/test_workflow_submitter.py
+++ b/tests/services/test_workflow_submitter.py
@@ -42,7 +42,9 @@ class TestWorkflowSubmitter:
                 MagicMock(returncode=0, stdout="New task added (id: 123).", stderr=""),
             ]
 
-            task_id = submitter.submit_workflow(case_path, pueue_group="test_group")
+            task_id = submitter.submit_workflow(
+                case_id=1, case_path=case_path, pueue_group="test_group"
+            )
 
             assert task_id == 123
             assert mock_run.call_count == 2
@@ -58,7 +60,7 @@ class TestWorkflowSubmitter:
             )
 
             with pytest.raises(WorkflowSubmissionError, match="Failed to copy case"):
-                submitter.submit_workflow(case_path)
+                submitter.submit_workflow(case_id=1, case_path=case_path)
             mock_run.assert_called_once()
 
     def test_submit_workflow_ssh_failure(self, mock_config):
@@ -73,7 +75,7 @@ class TestWorkflowSubmitter:
             ]
 
             with pytest.raises(WorkflowSubmissionError, match="Failed to submit job"):
-                submitter.submit_workflow(case_path)
+                submitter.submit_workflow(case_id=1, case_path=case_path)
             assert mock_run.call_count == 2
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -133,7 +133,9 @@ def test_main_loop_submits_case_with_available_gpu(mock_dependencies):
     mocks["db"].update_case_pueue_group.assert_called_once_with(4, "gpu_b")
 
     # Verify the submission
-    mocks["submitter"].submit_workflow.assert_called_once_with(case_path="/path/new", pueue_group="gpu_b")
+    mocks["submitter"].submit_workflow.assert_called_once_with(
+        case_id=4, case_path="/path/new", pueue_group="gpu_b"
+    )
     mocks["db"].update_case_pueue_task_id.assert_called_once_with(4, 201)
 
     # Verify status updates
@@ -187,7 +189,9 @@ def test_main_loop_handles_submission_id_failure(mock_dependencies):
 
     # Verify lock and submission attempt
     mocks["db"].find_and_lock_any_available_gpu.assert_called_once_with(6)
-    mocks["submitter"].submit_workflow.assert_called_once_with(case_path="/path/id_fail", pueue_group="gpu_a")
+    mocks["submitter"].submit_workflow.assert_called_once_with(
+        case_id=6, case_path="/path/id_fail", pueue_group="gpu_a"
+    )
 
     # Verify failure handling
     mocks["db"].update_case_completion.assert_called_once_with(6, status="failed")


### PR DESCRIPTION
A critical race condition was identified where the application could enter an inconsistent state if it crashed after submitting a job to the remote HPC but before updating the local database. This would result in an orphaned remote process and an incorrect local state, leading to resource conflicts.

This commit introduces a self-healing mechanism to address this:

-   `workflow_submitter` now adds a unique, predictable label (`mqic_case_{case_id}`) to each `pueue` job.
-   A new `find_task_by_label` method allows searching for remote jobs by this label.
-   The main application loop now includes recovery logic at startup. For any case found in the 'submitting' state, it checks the remote HPC for a job with the corresponding label.
    -   If found, the local state is healed by updating the case to 'running' with the correct task ID.
    -   If not found, the case is safely marked as 'failed' and the resource is released.

This change makes the application more resilient and prevents state inconsistencies. The test suite has been updated to reflect these changes, and the process has been documented in `dev_progress.md`.